### PR TITLE
Fix inactive member renewal date

### DIFF
--- a/penyamanager/admin/alertsview.cpp
+++ b/penyamanager/admin/alertsview.cpp
@@ -125,7 +125,7 @@ namespace PenyaManager {
             MemberPtr pMemberPtr = *iter;
             QPixmap icon = GuiUtils::getImage(":images/icon-inactive.png").scaled(35, 35);
             QString lastRenewalDateLocalized = Singletons::m_pTranslationManager->getLocale().
-                toString(pMemberPtr->m_inactiveModificationDate.startOfDay().toLocalTime(), QLocale::NarrowFormat);
+                toString(pMemberPtr->m_inactiveModificationDate, QLocale::NarrowFormat);
             QString message = tr("%1 %2 %3 (%4) has been inactive since %5 and not renewed").
                 arg(pMemberPtr->m_name).arg(pMemberPtr->m_surname1).arg(pMemberPtr->m_surname2).
                 arg(pMemberPtr->m_username).arg(lastRenewalDateLocalized);

--- a/penyamanager/admin/memberview.ui
+++ b/penyamanager/admin/memberview.ui
@@ -354,7 +354,7 @@ qproperty-alignment: AlignCenter;
             <item>
              <widget class="QLabel" name="label_7">
               <property name="text">
-               <string>Last renewal</string>
+               <string>Renewed until</string>
               </property>
              </widget>
             </item>

--- a/penyamanager/objs/Member.cpp
+++ b/penyamanager/objs/Member.cpp
@@ -1,7 +1,9 @@
 //
 
 #include <QObject>
+#include <QDate>
 
+#include <commons/constants.h>
 #include "Member.h"
 
 namespace PenyaManager
@@ -27,6 +29,23 @@ namespace PenyaManager
     bool Member::IsActive()
     {
         return m_active == ACTIVE;
+    }
+    //
+    bool Member::IsInactivityExpired()
+    {
+        if (!ExpirationDate().isValid()){
+            return false;
+        }
+        return ExpirationDate() <= QDate::currentDate();
+    }
+    //
+    QDate Member::ExpirationDate()
+    {
+        if (!m_inactiveModificationDate.isValid()){
+            return QDate();
+        }
+
+        return m_inactiveModificationDate.addMonths(Constants::kAdminInactivityPeriodMonths);
     }
     //
     MemberListStats::MemberListStats()

--- a/penyamanager/objs/Member.h
+++ b/penyamanager/objs/Member.h
@@ -38,6 +38,10 @@ namespace PenyaManager
             virtual ~Member(){}
             //
             bool IsActive();
+            //
+            bool IsInactivityExpired();
+            //
+            QDate ExpirationDate();
 
         public:
             //


### PR DESCRIPTION
Renewal from the expiring date. 

In the alert manager, show date, not datetime